### PR TITLE
Feature/Assets 292: Benutzer Löschen

### DIFF
--- a/kubernetes/helm/swissgeol-assets/templates/deployment.api.yaml
+++ b/kubernetes/helm/swissgeol-assets/templates/deployment.api.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-api
     spec:
+      serviceAccountName: cognito
       containers:
       - name: {{ .Release.Name }}-api
         image: {{ .Values.image_api }}
@@ -58,6 +59,10 @@ spec:
                 key: s3SecretAccessKey
           - name: S3_ASSET_FOLDER
             value: {{ .Values.s3_asset_folder }}
+          - name: COGNITO_REGION
+            value: {{ .Values.cognito_region }}
+          - name: COGNITO_POOL_ID
+            value: {{ .Values.cognito_pool_id }}
           - name: OAUTH_ISSUER
             value: {{ .Values.oauth_issuer }}
           - name: OAUTH_CLIENT_ID
@@ -80,12 +85,12 @@ spec:
             value: ''
           - name: OCR_CALLBACK_URL
             value: ''
-        resources:
-          limits:
-            cpu: '0.6'
-            memory: 1Gi
-          requests:
-            cpu: '0.6'
-            memory: 500Mi
+#        resources:
+#          limits:
+#            cpu: '0.6'
+#            memory: 1Gi
+#          requests:
+#            cpu: '0.6'
+#            memory: 500Mi
       imagePullSecrets:
       - name: {{ .Release.Namespace }}-registry

--- a/kubernetes/helm/swissgeol-assets/templates/deployment.ocr.yaml
+++ b/kubernetes/helm/swissgeol-assets/templates/deployment.ocr.yaml
@@ -40,6 +40,6 @@ spec:
         resources:
           limits:
             cpu: '0.5'
-            memory: 250Mi
+            memory: '2Gi'
       imagePullSecrets:
       - name: {{ .Release.Namespace }}-registry

--- a/kubernetes/helm/swissgeol-assets/templates/service-account.cognito.yaml
+++ b/kubernetes/helm/swissgeol-assets/templates/service-account.cognito.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cognito
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.cognito_service_account_role }}


### PR DESCRIPTION
Adds a service account to access Cognito, as well as some configuration variables for that purpose.

Note that this PR also contains changes to the APIs resources. With the current configuration, the K8s Dev Cluster does not have enough resources to automatically deploy the API when a new Asset Image is deployed. This is due to Keel starting the new version's instance in parallel, and only stopping the old one when the new one is fully up and running.

I would just roll with the configuration of this PR, and check on INT if we have any performance problems. I don't expect any at this moment, which is why I'm proposing pushing this change.